### PR TITLE
Differentiate indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 `npm install array-to-wavefront-obj`
 
+## Examples
+
 ```javascript
 var toOBJ = require('array-to-wavefront-obj');
 
@@ -15,6 +17,7 @@ console.log(objStr);
 ```
 
 prints the string
+
 ```
 # Created by array-to-wavefront-obj, a free and open source
 # OBJ serializer for JavaScript
@@ -30,7 +33,7 @@ vt 0.5 1
 f 1/1/1 2/2/2 3/3/3
 ```
 
-if the textures array is empty, then we would wind up with the string:
+### If the textures array is empty, then we would wind up with the string:
 
 ```
 # Created by array-to-wavefront-obj, a free and open source
@@ -44,3 +47,33 @@ vn 0 0 1
 f 1//1 2//2 3//3
 ```
 
+### It is also possible to specify different indices for the normals and the textures:
+
+```javascript
+var toOBJ = require('array-to-wavefront-obj');
+
+var vertices = [-1.0, -1.0, 0.0,   1.0, -1.0, 0.0,   0.0, 1.0, 0.0];
+var normals =  [ 0.0,  0.0, 1.0 ];
+var textures = [0.0, 0.0,   1.0, 0.0,   0.5, 1.0];
+var vertexIndices = [0, 1, 2];
+var textureIndices = [0, 1, 2];
+var normalIndices = [0, 0, 0]; // use the first normal for all the vertices
+
+var objStr = toOBJ(vertices, normals, textures, vertexIndices, normalIndices, textureIndices);
+console.log(objStr);
+```
+
+print the string
+
+```
+# Created by array-to-wavefront-obj, a free and open source
+# OBJ serializer for JavaScript
+v -1 -1 0
+v 1 -1 0
+v 0 1 0
+vn 0 0 1
+vt 0 0
+vt 1 0
+vt 0.5 1
+f 1/1/1 2/2/1 3/3/1
+```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ var objStr = toOBJ(vertices, normals, textures, vertexIndices, normalIndices, te
 console.log(objStr);
 ```
 
-print the string
+prints the string
 
 ```
 # Created by array-to-wavefront-obj, a free and open source

--- a/toOBJ.js
+++ b/toOBJ.js
@@ -3,17 +3,26 @@
     for (var j = 0; j < n; ++j) prefix += array[i + j] + (j === n - 1 ? '' : ' ');
     return prefix + '\n';
   };
-  function fLine (array, i, texturesFlag) {
+  function fLine (vertexIndices, normalIndices, textureIndices, i, texturesFlag) {
     var str = 'f ';
     // Faces are 1-indexed, hello Lua
-    var a = array[i] + 1;
-    var b = array[i + 1] + 1;
-    var c = array[i + 2] + 1;
-    str += a + '/' + (texturesFlag ? a : '') + '/' + a + ' ';
-    str += b + '/' + (texturesFlag ? b : '') + '/' + b + ' ';
-    return str + c + '/' + (texturesFlag ? c : '') + '/' + c + '\n';
+    var va = vertexIndices[i] + 1;
+    var vb = vertexIndices[i + 1] + 1;
+    var vc = vertexIndices[i + 2] + 1;
+    var na = normalIndices[i] + 1;
+    var nb = normalIndices[i + 1] + 1;
+    var nc = normalIndices[i + 2] + 1;
+    var ta = textureIndices[i] + 1;
+    var tb = textureIndices[i + 1] + 1;
+    var tc = textureIndices[i + 2] + 1;
+    str += va + '/' + (texturesFlag ? ta : '') + '/' + na + ' ';
+    str += vb + '/' + (texturesFlag ? tb : '') + '/' + nb + ' ';
+    return str + vc + '/' + (texturesFlag ? tc : '') + '/' + nc + '\n';
   };
-  function toOBJ (vertices, normals, textures, indices) {
+  function toOBJ (vertices, normals, textures, vertexIndices, normalIndices, textureIndices) {
+    normalIndices = normalIndices || vertexIndices;
+    textureIndices = textureIndices || vertexIndices;
+
     var str = '# Created by array-to-wavefront-obj, a free and open source\n';
     str +=    '# OBJ serializer for JavaScript\n';
     var i = 0;
@@ -29,8 +38,8 @@
         str += line('vt ', textures, i, 2);
       }
     }
-    for (i = 0; i < indices.length; i += 3) {
-      str += fLine(indices, i, hasTextures);
+    for (i = 0; i < vertexIndices.length; i += 3) {
+      str += fLine(vertexIndices, normalIndices, textureIndices, i, hasTextures);
     }
     return str;
   };


### PR DESCRIPTION
This PR adds optional indices arguments for the normals and the textures.

Differentiating the normal and texture indices from the vertex indices can help reduce the size of the final obj string.

In my specific use case (involving voxels) I have moderately complex geometries with thousands of vertices but only 6 different possible normal values.
